### PR TITLE
Fix/fixing req usage

### DIFF
--- a/src/controllers/machine.controller.ts
+++ b/src/controllers/machine.controller.ts
@@ -32,7 +32,9 @@ export class MachineController {
 
   public updateMachine = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const result = await updateMachine(req.body, req.params)
+      const { id } = req.params
+
+      const result = await updateMachine(req.body, id)
       sendResponse(req, res, result, 204)
     } catch (error) {
       if (error instanceof CustomError) {
@@ -45,7 +47,9 @@ export class MachineController {
 
   public deleteMachine = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const result = await deleteMachine(req.params)
+      const { id } = req.params
+
+      const result = await deleteMachine(id)
       sendResponse(req, res, result, 204)
     } catch (error) {
       if (error instanceof CustomError) {

--- a/src/controllers/machine.controller.ts
+++ b/src/controllers/machine.controller.ts
@@ -19,7 +19,7 @@ export class MachineController {
 
   public createMachine = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const newMachine = await createMachine(req)
+      const newMachine = await createMachine(req.body)
       sendResponse(req, res, newMachine, 201)
     } catch (error) {
       if (error instanceof CustomError) {
@@ -32,7 +32,7 @@ export class MachineController {
 
   public updateMachine = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const result = await updateMachine(req)
+      const result = await updateMachine(req.body, req.params)
       sendResponse(req, res, result, 204)
     } catch (error) {
       if (error instanceof CustomError) {
@@ -45,7 +45,7 @@ export class MachineController {
 
   public deleteMachine = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const result = await deleteMachine(req)
+      const result = await deleteMachine(req.params)
       sendResponse(req, res, result, 204)
     } catch (error) {
       if (error instanceof CustomError) {

--- a/src/models/Machine.ts
+++ b/src/models/Machine.ts
@@ -1,8 +1,8 @@
 import mongoose from "mongoose"
 
 export interface MachineInterface {
-    name: string,
-    description: string,
+  name: string,
+  description: string,
 }
 
 const machineSchema = new mongoose.Schema({

--- a/src/repositories/machine.repo.ts
+++ b/src/repositories/machine.repo.ts
@@ -1,11 +1,11 @@
-import { Types } from "mongoose";
+import { Types, HydratedDocument, UpdateResult, DeleteResult } from "mongoose";
 import { Machine, MachineInterface } from "../models/Machine"
 
-export const getAll = async () => {
+export const getAll = async (): Promise<MachineInterface[]> => {
   return await Machine.find();
 }
 
-export const createNewMachine = async (data: MachineInterface ) => {
+export const createNewMachine = async (data: MachineInterface): Promise<HydratedDocument<MachineInterface>> => {
   const { name, description } = data
 
   const newMachine = new Machine({ name, description })
@@ -17,7 +17,7 @@ export const existsMachine = async (id: Types.ObjectId): Promise<boolean> => {
   return Boolean(result)
 }
 
-export const updateMachineById = async (id: Types.ObjectId, data: Partial<MachineInterface>) => {
+export const updateMachineById = async (id: Types.ObjectId, data: Partial<MachineInterface>): Promise<UpdateResult> => {
   const { name, description } = data
   
   const updatedMachine = await Machine.updateOne({ _id: id }, {
@@ -30,7 +30,7 @@ export const updateMachineById = async (id: Types.ObjectId, data: Partial<Machin
   return updatedMachine
 }
 
-export const deleteMachineById = async (id: Types.ObjectId) => {
+export const deleteMachineById = async (id: Types.ObjectId): Promise<DeleteResult> => {
   return Machine.deleteOne({
     _id: id
   })

--- a/src/services/machine.service.ts
+++ b/src/services/machine.service.ts
@@ -28,9 +28,7 @@ export const createMachine = async (body: MachineInterface) => {
   return newMachine
 }
 
-export const updateMachine = async (body: Partial<MachineInterface>, params: ParamsDictionary) => {
-  const { id } = params
-
+export const updateMachine = async (body: Partial<MachineInterface>, id: string) => {
   if (!mongoose.Types.ObjectId.isValid(id)) {
     throw new CustomError("Id inválida", 400, ["Id inválida"])
   }
@@ -54,9 +52,7 @@ export const updateMachine = async (body: Partial<MachineInterface>, params: Par
   return updatedMachine
 }
 
-export const deleteMachine = async (params: ParamsDictionary) => {
-  const { id } = params
-
+export const deleteMachine = async (id: string) => {
   if (!mongoose.Types.ObjectId.isValid(id)) {
     throw new CustomError("Id inválida", 400, ["Id inválida"])
   }

--- a/src/services/machine.service.ts
+++ b/src/services/machine.service.ts
@@ -25,6 +25,7 @@ export const createMachine = async (body: MachineInterface) => {
   }
 
   const newMachine = await createNewMachine(parsedData.data)
+  console.log(newMachine)
   return newMachine
 }
 

--- a/src/services/machine.service.ts
+++ b/src/services/machine.service.ts
@@ -1,8 +1,9 @@
-import { Request } from "express";
 import { CustomError } from "../middlewares/errorHandler";
 import { createNewMachine, deleteMachineById, existsMachine, getAll, updateMachineById } from "../repositories/machine.repo";
 import { MachineSchema, UpdateMachineSchema } from "../utils/machineValidator";
 import mongoose, { Types } from "mongoose";
+import { MachineInterface } from "../models/Machine";
+import { ParamsDictionary } from "express-serve-static-core";
 
 export const getAllMachines = async () => {
   const data = await getAll();
@@ -14,8 +15,8 @@ export const getAllMachines = async () => {
   return data;
 }
 
-export const createMachine = async (req: Request) => {
-  const parsedData = MachineSchema.safeParse(req.body)
+export const createMachine = async (body: MachineInterface) => {
+  const parsedData = MachineSchema.safeParse(body)
 
   if (!parsedData.success) {
     const message = parsedData.error.issues.map((issue) => issue.message)
@@ -27,8 +28,8 @@ export const createMachine = async (req: Request) => {
   return newMachine
 }
 
-export const updateMachine = async (req: Request) => {
-  const { id } = req.params
+export const updateMachine = async (body: Partial<MachineInterface>, params: ParamsDictionary) => {
+  const { id } = params
 
   if (!mongoose.Types.ObjectId.isValid(id)) {
     throw new CustomError("Id inválida", 400, ["Id inválida"])
@@ -42,7 +43,7 @@ export const updateMachine = async (req: Request) => {
     throw new CustomError("Máquina no encontrada", 404, ["Máquina no encontrada"])
   }
 
-  const parse = UpdateMachineSchema.safeParse(req.body)
+  const parse = UpdateMachineSchema.safeParse(body)
 
   if (!parse.success) {
     const message = parse.error.issues.map((issues) => issues.message)
@@ -53,8 +54,8 @@ export const updateMachine = async (req: Request) => {
   return updatedMachine
 }
 
-export const deleteMachine = async (req: Request) => {
-  const { id } = req.params
+export const deleteMachine = async (params: ParamsDictionary) => {
+  const { id } = params
 
   if (!mongoose.Types.ObjectId.isValid(id)) {
     throw new CustomError("Id inválida", 400, ["Id inválida"])


### PR DESCRIPTION
# Arreglar problema de usar el req.body en el servicio

## ¿Por qué se hizo? 🥸

🔗 Solo el controller debería trabajar con la request y pasar el body/params a los servicios

## ¿Qué se hizo? 🪚

Se cambió el tipo de dato y variable que reciben los servicios de las máquinas para aceptar directamente el body/params, y en el controller se pasa el req.body o req.params según corresponda


## ¿Cómo se prueba esto? 🧪

Revisar que sigan funcionando los endpoints